### PR TITLE
fix: add new line before divider

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -84,7 +84,7 @@ function getCommitTasks(commits: Octokit.Response<Octokit.PullsListCommitsRespon
 
 
 function tasksToComment(taskState: object): string | undefined {
-  const result = [DIVIDER];
+  const result = [`\r\n${DIVIDER}`];
   const entires = Object.entries(taskState);
   if (entires.length == 0)
     return undefined;


### PR DESCRIPTION
This PR adds a new line before the divider, just to ensure that the Pre-flight text doesn't interfere with previous text in the PR (e.g. bulleted list).